### PR TITLE
fix string:lowercase undefine in old version, like (R16B02)

### DIFF
--- a/src/csv_parser.erl
+++ b/src/csv_parser.erl
@@ -128,13 +128,7 @@ trans2erlang_type({string, _Defalut}, Data) ->
 trans2erlang_type({integer, _Defalut}, Data) ->
   trans2erlang_integer(Data);
 trans2erlang_type({bool, Defalut}, BoolStr) -> 
-  Bool = list_to_atom(string:lowercase(BoolStr)),
-  case Bool =:= false orelse Bool =:= true of
-    true ->
-      Bool;
-    false ->
-      error_exit({unexcept_type, {bool, Defalut}, BoolStr})
-  end;
+  trans2erlang_bool(Defalut, BoolStr);
 trans2erlang_type(ErlType, Unkonw) ->
   error_exit({unexcept_type, ErlType, Unkonw}).
 
@@ -147,6 +141,25 @@ trans2erlang_integer(Data) ->
     catch _:_ ->
       error_exit({error_integer, Data})
     end
+  end.
+
+trans2erlang_bool(Default, BoolStr) ->
+  BoolAtom = 
+    try
+      string:lowercase(BoolStr)
+    catch _:_ ->
+      try 
+        string:to_lower(BoolStr)
+      catch _:_ ->
+          error_exit({error_bool, BoolStr})
+      end
+    end,
+  Bool = list_to_atom(BoolAtom),
+  case Bool =:= false orelse Bool =:= true of
+    true ->
+      Bool;
+    false ->
+      error_exit({unexcept_type, {bool, Default}, BoolStr})
   end.
 
 error_exit(Error) ->


### PR DESCRIPTION
在一些旧版本erlang，模块string没有lowercase这个方法，我使用了to_lower这个方法，你可参考改改吧，to_lower这个方法貌似已经被废弃掉了。可能现在也没有人用这么低版本了吧，你也可以忽略我的建议。
![image](https://user-images.githubusercontent.com/29625907/39111168-b9c543ba-4706-11e8-84a5-7252495c4dd7.png)
